### PR TITLE
Upgrade to .NET 10 and migrate to Azure.Storage.Blobs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      VERSION_NUMBER: "9.0"
+      VERSION_NUMBER: "10.0"
       NUGET_KEY: ${{ secrets.NUGET_KEY }}
 
     steps:
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -36,7 +36,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/integration-tests.yml
     with:
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
     secrets:
       GOOGLE_AUTH_JSON: ${{ secrets.GOOGLE_AUTH_JSON }}
 
@@ -44,7 +44,7 @@ jobs:
     needs: integration-tests
     runs-on: ubuntu-latest
     env:
-      VERSION_NUMBER: "9.0"
+      VERSION_NUMBER: "10.0"
       NUGET_KEY: ${{ secrets.NUGET_KEY }}
 
     steps:
@@ -54,7 +54,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
         description: '.NET version to use'
         required: false
         type: string
-        default: '9.0.x'
+        default: '10.0.x'
     secrets:
       GOOGLE_AUTH_JSON:
         description: 'Google Cloud service account JSON'
@@ -18,7 +18,7 @@ on:
         description: '.NET version to use'
         required: false
         type: string
-        default: '9.0.x'
+        default: '10.0.x'
 
 jobs:
   integration-tests:
@@ -51,7 +51,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    - name: Start LocalStack and Azurite services
+    - name: Start moto and Azurite services
       working-directory: src/CloudFileStore.Tests
       run: docker compose up -d
 
@@ -63,8 +63,8 @@ jobs:
         echo "Checking service health..."
         docker ps
 
-        # Wait for LocalStack to be ready
-        timeout 30 bash -c 'until curl -s http://localhost:4566/_health | grep -q "\"s3\":\"running\""; do sleep 1; done' || echo "LocalStack health check timeout"
+        # Wait for moto to be ready
+        timeout 30 bash -c 'until curl -s http://localhost:4566/moto-api/ > /dev/null 2>&1; do sleep 1; done' || echo "moto health check timeout"
 
         # Verify Azurite is responding
         timeout 10 bash -c 'until curl -s http://localhost:10000/devstoreaccount1?comp=list; do sleep 1; done' || echo "Azurite connection check timeout"
@@ -75,8 +75,8 @@ jobs:
       if: always()
       working-directory: src/CloudFileStore.Tests
       run: |
-        echo "=== LocalStack Logs ==="
-        docker compose logs localstack
+        echo "=== moto Logs ==="
+        docker compose logs moto
         echo "=== Azurite Logs ==="
         docker compose logs azurite
         echo "=== Init Logs ==="

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<!-- Common target framework -->
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 
 		<!-- Package metadata -->
 		<Authors>C.Small</Authors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,20 @@
 
 	<ItemGroup>
 		<!-- Cloud Provider SDKs -->
-		<PackageVersion Include="AWSSDK.S3" Version="4.0.8" />
-		<PackageVersion Include="Google.Cloud.Storage.V1" Version="4.13.0" />
-		<PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
+		<PackageVersion Include="AWSSDK.S3" Version="4.0.24.4" />
+		<PackageVersion Include="Google.Cloud.Storage.V1" Version="4.15.0" />
+		<PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
 
 		<!-- Microsoft Extensions (Configuration) -->
-		<PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
 
 		<!-- Testing Framework -->
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageVersion Include="Shouldly" Version="4.3.0" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.300",
     "rollForward": "latestPatch"
   }
 }

--- a/src/CloudFileStore.Tests/Integration/AzureBlogStorageProviderTests.cs
+++ b/src/CloudFileStore.Tests/Integration/AzureBlogStorageProviderTests.cs
@@ -1,6 +1,6 @@
+using Azure.Storage.Blobs;
 using CloudFileStore.Azure;
 using Microsoft.Extensions.Configuration;
-using Microsoft.WindowsAzure.Storage;
 using Xunit.Abstractions;
 
 namespace CloudFileStore.Tests.Integration
@@ -17,7 +17,6 @@ namespace CloudFileStore.Tests.Integration
             IConfigurationSection section = configuration.GetSection("AzureBlobConfiguration");
             section.Bind(_azureBlobConfiguration);
 
-            // Ensure test Azure container exists for tests 
             EnsureAzureContainerExists();
 
             outputHelper.WriteLine($"Azure container: {_azureBlobConfiguration.ContainerName}");
@@ -25,11 +24,8 @@ namespace CloudFileStore.Tests.Integration
 
         private void EnsureAzureContainerExists()
         {
-            CloudStorageAccount storageAccount;
-            CloudStorageAccount.TryParse(_azureBlobConfiguration.ConnectionString, out storageAccount);
-
-            var client = storageAccount.CreateCloudBlobClient();
-            var container = client.GetContainerReference(_azureBlobConfiguration.ContainerName);
+            var blobServiceClient = new BlobServiceClient(_azureBlobConfiguration.ConnectionString);
+            var container = blobServiceClient.GetBlobContainerClient(_azureBlobConfiguration.ContainerName);
             container.CreateIfNotExistsAsync().GetAwaiter().GetResult();
         }
 

--- a/src/CloudFileStore.Tests/appsettings.json
+++ b/src/CloudFileStore.Tests/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
-  // AWS is tested using LocalStack
+  // AWS is tested using moto
   "S3Configuration": {
     "BucketName": "test-bucket",
     "AccessKey": "test",

--- a/src/CloudFileStore.Tests/docker-compose.yml
+++ b/src/CloudFileStore.Tests/docker-compose.yml
@@ -1,20 +1,11 @@
 services:
-  # AWS S3 Emulator (LocalStack)
-  localstack:
-    image: localstack/localstack:latest
+  # AWS S3 Emulator (moto)
+  moto:
+    image: motoserver/moto:latest
     ports:
-      - "4566:4566"
-      - "4510-4559:4510-4559"
+      - "4566:5000"
     environment:
-      - SERVICES=s3
-      - DEBUG=0
-      - PERSISTENCE=1
-      - AWS_ACCESS_KEY_ID=test
-      - AWS_SECRET_ACCESS_KEY=test
-      - AWS_DEFAULT_REGION=us-east-1
-    volumes:
-      - ./test-data/localstack:/var/lib/localstack
-      - /var/run/docker.sock:/var/run/docker.sock
+      - MOTO_PORT=5000
 
   # Azure Blob Storage Emulator (Azurite)
   azurite:
@@ -23,7 +14,7 @@ services:
       - "10000:10000"  # Blob service
       - "10001:10001"  # Queue service
       - "10002:10002"  # Table service
-    command: "azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose"
+    command: "azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose --skipApiVersionCheck"
     volumes:
       - ./test-data/azurite:/data
 
@@ -31,7 +22,7 @@ services:
   init:
     image: amazon/aws-cli:latest
     depends_on:
-      - localstack
+      - moto
       - azurite
     environment:
       - AWS_ACCESS_KEY_ID=test
@@ -46,10 +37,10 @@ services:
 
         echo "Initializing cloud storage emulators..."
 
-        # Create S3 bucket in LocalStack (with retries)
+        # Create S3 bucket in moto (with retries)
         echo "Creating S3 bucket..."
         for i in 1 2 3 4 5; do
-          aws --endpoint-url=http://localstack:4566 s3 mb s3://test-bucket && break || sleep 5
+          aws --endpoint-url=http://moto:5000 s3 mb s3://test-bucket && break || sleep 5
         done
 
         # Create Azure container (with retries)
@@ -73,5 +64,5 @@ services:
     restart: "no"
 
 volumes:
-  localstack-data:
+  moto-data:
   azurite-data:

--- a/src/CloudFileStore/Azure/AzureBlobStorageProvider.cs
+++ b/src/CloudFileStore/Azure/AzureBlobStorageProvider.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.File;
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,67 +11,61 @@ namespace CloudFileStore.Azure
     public class AzureBlobStorageProvider : IStorageProvider
     {
         private readonly AzureBlobConfiguration _configuration;
-        private readonly CloudBlobContainer _blobContainer;
-        private BlobContinuationToken _continuationToken;
+        private readonly BlobContainerClient _blobContainer;
+        private string _continuationToken;
 
         public AzureBlobStorageProvider(AzureBlobConfiguration configuration)
         {
             _configuration = configuration;
 
-            CloudStorageAccount storageAccount;
-            CloudStorageAccount.TryParse(configuration.ConnectionString, out storageAccount);
-
-            var client = storageAccount.CreateCloudBlobClient();
-            _blobContainer = client.GetContainerReference(configuration.ContainerName);
+            var blobServiceClient = new BlobServiceClient(configuration.ConnectionString);
+            _blobContainer = blobServiceClient.GetBlobContainerClient(configuration.ContainerName);
         }
 
         public async Task DeleteFileAsync(string filename)
         {
-            var blob = _blobContainer.GetBlobReference(filename);
-            await blob.DeleteIfExistsAsync();
+            var blobClient = _blobContainer.GetBlobClient(filename);
+            await blobClient.DeleteIfExistsAsync();
         }
 
         public async Task<bool> FileExistsAsync(string filename)
         {
-            var blob = _blobContainer.GetBlobReference(filename);
-            return await blob.ExistsAsync();
+            var blobClient = _blobContainer.GetBlobClient(filename);
+            var response = await blobClient.ExistsAsync();
+            return response.Value;
         }
 
         public async Task<IEnumerable<string>> ListFilesAsync(int pageSize = 100, bool pagingEnabled = true)
         {
-            BlobResultSegment segment = null;
+            var blobs = _blobContainer.GetBlobsAsync();
+            var pages = blobs.AsPages(pagingEnabled ? _continuationToken : null, pageSize);
 
-            if (pagingEnabled)
+            var results = new List<string>();
+            await foreach (var page in pages)
             {
-                segment = await _blobContainer.ListBlobsSegmentedAsync("", true, BlobListingDetails.All, pageSize, _continuationToken, new BlobRequestOptions(), new OperationContext());
-                _continuationToken = segment.ContinuationToken;
-            }
-            else
-            {
-                segment = await _blobContainer.ListBlobsSegmentedAsync(null);
+                _continuationToken = page.ContinuationToken;
+                results.AddRange(page.Values.Select(x => x.Name));
+                break;
             }
 
-            return segment.Results
-                          .Select(x => Path.GetFileName(x.Uri.LocalPath));
+            return results;
         }
 
         public async Task<string> LoadTextFileAsync(string filename)
         {
-            CloudBlob blob = _blobContainer.GetBlobReference(filename);
-
-            using (var stream = await blob.OpenReadAsync())
-            {
-                using (var reader = new StreamReader(stream))
-                {
-                    return await reader.ReadToEndAsync();
-                }
-            }
+            var blobClient = _blobContainer.GetBlobClient(filename);
+            var response = await blobClient.DownloadContentAsync();
+            return response.Value.Content.ToString();
         }
 
         public async Task SaveTextFileAsync(string filePath, string fileContent, string contentType = "text/plain")
         {
-            CloudBlockBlob blob = _blobContainer.GetBlockBlobReference(filePath);
-            await blob.UploadTextAsync(fileContent);
+            var blobClient = _blobContainer.GetBlobClient(filePath);
+            var options = new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders { ContentType = contentType }
+            };
+            await blobClient.UploadAsync(new BinaryData(fileContent), options);
         }
     }
 }

--- a/src/CloudFileStore/CloudFileStore.csproj
+++ b/src/CloudFileStore/CloudFileStore.csproj
@@ -20,6 +20,6 @@
 	<ItemGroup>
 		<PackageReference Include="Google.Cloud.Storage.V1" />
 		<PackageReference Include="AWSSDK.S3" />
-		<PackageReference Include="WindowsAzure.Storage" />
+		<PackageReference Include="Azure.Storage.Blobs" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Upgrades the library to .NET 10 (LTS) and upgrades all NuGet packages to their latest versions.

### Framework changes
- Target framework: `net9.0` -> `net10.0`
- SDK: `9.0.300` -> `10.0.300`

### Package upgrades
| Package | Old | New |
|---|---|---|
| AWSSDK.S3 | 4.0.8 | 4.0.24.4 |
| Google.Cloud.Storage.V1 | 4.13.0 | 4.15.0 |
| Microsoft.Extensions.* | 9.0.10 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.0.0 | 18.6.0 |
| ~~WindowsAzure.Storage~~ (deprecated) | 9.3.3 | replaced by Azure.Storage.Blobs 12.29.0 |

### Azure SDK migration
Replaced the deprecated `WindowsAzure.Storage` package with the modern `Azure.Storage.Blobs` SDK. The API is completely different, requiring changes to:
- `AzureBlobStorageProvider.cs` — migrated from `CloudBlobContainer`/`CloudBlockBlob` to `BlobContainerClient`/`BlobClient`
- `AzureBlogStorageProviderTests.cs` — migrated from `CloudStorageAccount` to `BlobServiceClient`

### Test infrastructure changes
- Switched S3 test emulator from **LocalStack** to **moto** (motoserver/moto) — LocalStack latest now requires a license token
- Added `--skipApiVersionCheck` to Azurite — needed because `Azure.Storage.Blobs` 12.29.0 uses API version `2026-06-06` which Azurite 3.35.0 doesn't yet recognise
- Updated CI workflows (`dotnet.yml`, `integration-tests.yml`) to .NET 10 and moto

### Verification
- Build succeeds with 0 errors
- All 7 S3 tests pass against moto
- All 7 Azure tests pass against Azurite
- Google Cloud tests require real credentials (unchanged, pre-existing requirement)
